### PR TITLE
feat: merge packets to compose feedback struct

### DIFF
--- a/src/Driver.cpp
+++ b/src/Driver.cpp
@@ -14,9 +14,9 @@ int Driver::extractPacket(uint8_t const* buffer, size_t buffer_size) const
     return protocol::extractPacket(buffer, buffer_size);
 }
 
-SmartShuntFeedback Driver::processOne()
+SmartShuntFeedback Driver::processOne(int needed_packets)
 {
-    if (m_processed_packets_counter >= 2) {
+    if (m_processed_packets_counter >= needed_packets) {
         // Reset feedback
         m_feedback = SmartShuntFeedback();
         m_processed_packets_counter = 0;

--- a/src/Driver.cpp
+++ b/src/Driver.cpp
@@ -6,6 +6,7 @@ using namespace bms_victron_smart_shunt;
 Driver::Driver()
     : iodrivers_base::Driver::Driver(INTERNAL_BUFFER_SIZE)
 {
+    m_processed_packets_counter = 0;
 }
 
 int Driver::extractPacket(uint8_t const* buffer, size_t buffer_size) const
@@ -15,6 +16,18 @@ int Driver::extractPacket(uint8_t const* buffer, size_t buffer_size) const
 
 SmartShuntFeedback Driver::processOne()
 {
+    if (m_processed_packets_counter >= 2) {
+        // Reset feedback
+        m_feedback = SmartShuntFeedback();
+        m_processed_packets_counter = 0;
+    }
     int packet_size = readPacket(m_read_buffer, INTERNAL_BUFFER_SIZE);
-    return protocol::parseSmartShuntFeedback(m_read_buffer, packet_size);
+    protocol::parseSmartShuntFeedback(m_read_buffer, packet_size, m_feedback);
+    m_processed_packets_counter += 1;
+    return m_feedback;
+}
+
+int Driver::packetsCounter()
+{
+    return m_processed_packets_counter;
 }

--- a/src/Driver.hpp
+++ b/src/Driver.hpp
@@ -20,9 +20,11 @@ namespace bms_victron_smart_shunt {
         /**
          * @brief Process the internal buffer and parses the a found packet
          *
+         * @param needed_packets The number of needed packets to compose a full feedback
+         * update
          * @return SmartShuntFeedback
          */
-        SmartShuntFeedback processOne();
+        SmartShuntFeedback processOne(int needed_packets);
         /**
          * @brief Returns the number of packets processed to compose the current feedback
          * struct

--- a/src/Driver.hpp
+++ b/src/Driver.hpp
@@ -23,6 +23,13 @@ namespace bms_victron_smart_shunt {
          * @return SmartShuntFeedback
          */
         SmartShuntFeedback processOne();
+        /**
+         * @brief Returns the number of packets processed to compose the current feedback
+         * struct
+         *
+         * @return int
+         */
+        int packetsCounter();
 
     private:
         /**
@@ -38,6 +45,17 @@ namespace bms_victron_smart_shunt {
          *
          */
         uint8_t m_read_buffer[INTERNAL_BUFFER_SIZE];
+        /**
+         * @brief The Victron Smart Shunt Feedback
+         *
+         */
+        SmartShuntFeedback m_feedback;
+        /**
+         * @brief The number of processed packets used to compose the current feedback
+         * struct
+         *
+         */
+        int m_processed_packets_counter = 0;
     };
 }
 

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -9,10 +9,12 @@ using namespace bms_victron_smart_shunt;
 int usage()
 {
     cerr << "Usage: "
-         << "bms_victron_smart_shunt_ctl URI PERIOD\n"
+         << "bms_victron_smart_shunt_ctl URI PERIOD NEEDED_PACKETS \n"
          << "URI is a valid iodrivers_base URI, e.g. serial:///dev/ttyUSB0:19200\n"
          << "PERIOD is time interval in seconds between two outputs, the default value "
             "is 0.1 seconds\n"
+         << "NEEDED_PACKETS The number of packets needed to have a full feedback update\n"
+
          << flush;
     return 0;
 }
@@ -31,9 +33,13 @@ int main(int argc, char const* argv[])
     if (argv[2]) {
         poll_period_usec = atof(argv[2]) * 1000000;
     }
+    int needed_packets = 2;
+    if (argv[3]) {
+        needed_packets = atof(argv[3]);
+    }
 
     while (true) {
-        auto feedback = driver.processOne();
+        auto feedback = driver.processOne(needed_packets);
         if (driver.packetsCounter() >= 2) {
             cout << fixed << std::left << std::setw(42)
                  << "\nTimestamp: " << feedback.timestamp << std::left << std::setw(42)

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -30,11 +30,11 @@ int main(int argc, char const* argv[])
     driver.setWriteTimeout(base::Time::fromMilliseconds(1000));
     driver.openURI(uri);
     int poll_period_usec = 100000;
-    if (argv[2]) {
+    if (argc >= 3) {
         poll_period_usec = atof(argv[2]) * 1000000;
     }
     int needed_packets = 2;
-    if (argv[3]) {
+    if (argc >= 4) {
         needed_packets = atof(argv[3]);
     }
 

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -34,56 +34,60 @@ int main(int argc, char const* argv[])
 
     while (true) {
         auto feedback = driver.processOne();
-        cout << fixed << std::left << std::setw(42)
-             << "\nTimestamp: " << feedback.timestamp << std::left << std::setw(42)
-             << "\nProduct ID: " << feedback.product_id << std::left << std::setw(42)
-             << "\nVoltage: " << setprecision(3) << feedback.voltage << std::left
-             << std::setw(42) << "\nCurrent: " << feedback.current << std::left
-             << std::setw(42) << "\nInstantaneous power: " << setprecision(0)
-             << feedback.instantaneous_power << std::left << std::setw(42)
-             << "\nConsumed charge: " << setprecision(3) << feedback.consumed_charge
-             << std::left << std::setw(42) << "\nState of charge: " << setprecision(0)
-             << feedback.state_of_charge << std::left << std::setw(42)
-             << "\nTime to go (s): " << feedback.time_to_go.toSeconds() << std::left
-             << std::setw(42)
-             << "\nAlarm condition active: " << feedback.alarm_condition_active
-             << std::left << std::setw(42) << "\nAlarm reason: " << feedback.alarm_reason
-             << std::left << std::setw(42)
-             << "\nModel description: " << feedback.model_description << std::left
-             << std::setw(42) << "\nFirmware version: " << feedback.firmware_version
-             << std::left << std::setw(42)
-             << "\nDC monitor mode: " << feedback.dc_monitor_mode << std::left
-             << std::setw(42) << "\nCharged energy: " << feedback.charged_energy
-             << std::left << std::setw(42)
-             << "\nDeepest discharge depth: " << feedback.deepest_discharge_depth
-             << std::left << std::setw(42)
-             << "\nLast discharge depth: " << feedback.last_discharge_depth << std::left
-             << std::setw(42)
-             << "\nAverage discharge depth: " << feedback.average_discharge_depth
-             << std::left << std::setw(42)
-             << "\nCharge cycles number: " << feedback.charge_cycles_number << std::left
-             << std::setw(42)
-             << "\nFull discharges number: " << feedback.full_discharges_number
-             << std::left << std::setw(42)
-             << "\nCumulative charge drawn: " << feedback.cumulative_charge_drawn
-             << std::left << std::setw(42) << "\nMinimum voltage: " << setprecision(3)
-             << feedback.minimum_voltage << std::left << std::setw(42)
-             << "\nMaximum voltage: " << feedback.maximum_voltage << std::left
-             << std::setw(42) << "\nSeconds since last full charge: " << setprecision(0)
-             << feedback.seconds_since_last_full_charge.toSeconds() << std::left
-             << std::setw(42) << "\nNumber of automatic synchronizations: "
-             << feedback.automatic_synchronizations_number << std::left << std::setw(42)
-             << "\nNumber of low voltage alarms: " << feedback.low_voltage_alarms_number
-             << std::left << std::setw(42)
-             << "\nNumber of high voltage alarms: " << feedback.high_voltage_alarms_number
-             << std::left << std::setw(42)
-             << "\nMinimum auxiliary battery voltage: " << setprecision(3)
-             << feedback.minimum_auxiliary_battery_voltage << std::left << std::setw(42)
-             << "\nMaximum auxiliary battery voltage: "
-             << feedback.maximum_auxiliary_battery_voltage << std::left << std::setw(42)
-             << "\nDischarged energy: " << setprecision(0) << feedback.discharged_energy
-             << std::left << std::setw(42)
-             << "\nCharged energy: " << feedback.charged_energy << endl;
+        if (driver.packetsCounter() >= 2) {
+            cout << fixed << std::left << std::setw(42)
+                 << "\nTimestamp: " << feedback.timestamp << std::left << std::setw(42)
+                 << "\nProduct ID: " << feedback.product_id << std::left << std::setw(42)
+                 << "\nVoltage: " << setprecision(3) << feedback.voltage << std::left
+                 << std::setw(42) << "\nCurrent: " << feedback.current << std::left
+                 << std::setw(42) << "\nInstantaneous power: " << setprecision(0)
+                 << feedback.instantaneous_power << std::left << std::setw(42)
+                 << "\nConsumed charge: " << setprecision(3) << feedback.consumed_charge
+                 << std::left << std::setw(42) << "\nState of charge: " << setprecision(0)
+                 << feedback.state_of_charge << std::left << std::setw(42)
+                 << "\nTime to go (s): " << feedback.time_to_go.toSeconds() << std::left
+                 << std::setw(42)
+                 << "\nAlarm condition active: " << feedback.alarm_condition_active
+                 << std::left << std::setw(42)
+                 << "\nAlarm reason: " << feedback.alarm_reason << std::left
+                 << std::setw(42) << "\nModel description: " << feedback.model_description
+                 << std::left << std::setw(42)
+                 << "\nFirmware version: " << feedback.firmware_version << std::left
+                 << std::setw(42) << "\nDC monitor mode: " << feedback.dc_monitor_mode
+                 << std::left << std::setw(42)
+                 << "\nCharged energy: " << feedback.charged_energy << std::left
+                 << std::setw(42)
+                 << "\nDeepest discharge depth: " << feedback.deepest_discharge_depth
+                 << std::left << std::setw(42)
+                 << "\nLast discharge depth: " << feedback.last_discharge_depth
+                 << std::left << std::setw(42)
+                 << "\nAverage discharge depth: " << feedback.average_discharge_depth
+                 << std::left << std::setw(42)
+                 << "\nCharge cycles number: " << feedback.charge_cycles_number
+                 << std::left << std::setw(42)
+                 << "\nFull discharges number: " << feedback.full_discharges_number
+                 << std::left << std::setw(42)
+                 << "\nCumulative charge drawn: " << feedback.cumulative_charge_drawn
+                 << std::left << std::setw(42) << "\nMinimum voltage: " << setprecision(3)
+                 << feedback.minimum_voltage << std::left << std::setw(42)
+                 << "\nMaximum voltage: " << feedback.maximum_voltage << std::left
+                 << std::setw(42)
+                 << "\nSeconds since last full charge: " << setprecision(0)
+                 << feedback.seconds_since_last_full_charge.toSeconds() << std::left
+                 << std::setw(42) << "\nNumber of automatic synchronizations: "
+                 << feedback.automatic_synchronizations_number << std::left
+                 << std::setw(42) << "\nNumber of low voltage alarms: "
+                 << feedback.low_voltage_alarms_number << std::left << std::setw(42)
+                 << "\nNumber of high voltage alarms: "
+                 << feedback.high_voltage_alarms_number << std::left << std::setw(42)
+                 << "\nMinimum auxiliary battery voltage: " << setprecision(3)
+                 << feedback.minimum_auxiliary_battery_voltage << std::left
+                 << std::setw(42) << "\nMaximum auxiliary battery voltage: "
+                 << feedback.maximum_auxiliary_battery_voltage << std::left
+                 << std::setw(42) << "\nDischarged energy: " << setprecision(0)
+                 << feedback.discharged_energy << std::left << std::setw(42)
+                 << "\nCharged energy: " << feedback.charged_energy << endl;
+        }
         usleep(poll_period_usec);
     }
 }

--- a/src/Protocol.cpp
+++ b/src/Protocol.cpp
@@ -92,7 +92,7 @@ void protocol::parseSmartShuntFeedback(uint8_t const* buffer,
             }
             else if (field == "SOC") {
                 int val = stoi(value_s);
-                data.state_of_charge = val;
+                data.state_of_charge = static_cast<float>(val) / 10;
             }
             else if (field == "TTG") {
                 int val = stoi(value_s);

--- a/src/Protocol.cpp
+++ b/src/Protocol.cpp
@@ -42,13 +42,13 @@ int protocol::extractPacket(const uint8_t* buffer, int buffer_size)
     }
 }
 
-SmartShuntFeedback protocol::parseSmartShuntFeedback(uint8_t const* buffer,
-    int buffer_size)
+void protocol::parseSmartShuntFeedback(uint8_t const* buffer,
+    int buffer_size,
+    SmartShuntFeedback& data)
 {
-    SmartShuntFeedback data;
     data.timestamp = base::Time::now();
-    std::string data_str(reinterpret_cast<const char*>(buffer), buffer_size);
-    std::istringstream stream(data_str);
+    std::string feedback_str(reinterpret_cast<const char*>(buffer), buffer_size);
+    std::istringstream stream(feedback_str);
     std::string line;
     while (std::getline(stream, line, PACKET_START_MARKER)) {
         if (!line.empty()) {
@@ -200,5 +200,4 @@ SmartShuntFeedback protocol::parseSmartShuntFeedback(uint8_t const* buffer,
             }
         }
     }
-    return data;
 }

--- a/src/Protocol.hpp
+++ b/src/Protocol.hpp
@@ -26,8 +26,9 @@ namespace bms_victron_smart_shunt {
          * @param buffer_size The buffer size
          * @return SmartShuntFeedback
          */
-        SmartShuntFeedback parseSmartShuntFeedback(uint8_t const* buffer,
-            int buffer_size);
+        void parseSmartShuntFeedback(uint8_t const* buffer,
+            int buffer_size,
+            SmartShuntFeedback& feedback);
     }
 }
 

--- a/test/test_Driver.cpp
+++ b/test/test_Driver.cpp
@@ -59,7 +59,7 @@ TEST_F(DriverTest, it_accepts_a_full_packet)
     ASSERT_EQ(feedback.current, 0);
     ASSERT_NEAR(feedback.instantaneous_power, 0, 1e-3);
     ASSERT_EQ(feedback.consumed_charge, 0);
-    ASSERT_NEAR(feedback.state_of_charge, 1000, 1e-3);
+    ASSERT_NEAR(feedback.state_of_charge, 100, 1e-3);
     ASSERT_EQ(feedback.time_to_go.toSeconds(), -60);
     ASSERT_EQ(feedback.alarm_condition_active, "OFF");
     ASSERT_EQ(feedback.relay_state, "OFF");
@@ -109,7 +109,7 @@ TEST_F(DriverTest, the_packet_arrives_little_by_little)
     ASSERT_EQ(feedback.current, 0);
     ASSERT_NEAR(feedback.instantaneous_power, 0, 1e-3);
     ASSERT_EQ(feedback.consumed_charge, 0);
-    ASSERT_NEAR(feedback.state_of_charge, 1000, 1e-3);
+    ASSERT_NEAR(feedback.state_of_charge, 100, 1e-3);
     ASSERT_EQ(feedback.time_to_go.toSeconds(), -60);
     ASSERT_EQ(feedback.alarm_condition_active, "OFF");
     ASSERT_EQ(feedback.relay_state, "OFF");
@@ -138,7 +138,7 @@ TEST_F(DriverTest, it_accepts_a_packet_with_garbage_at_the_beginning)
     ASSERT_EQ(feedback.current, 0);
     ASSERT_NEAR(feedback.instantaneous_power, 0, 1e-3);
     ASSERT_EQ(feedback.consumed_charge, 0);
-    ASSERT_NEAR(feedback.state_of_charge, 1000, 1e-3);
+    ASSERT_NEAR(feedback.state_of_charge, 100, 1e-3);
     ASSERT_EQ(feedback.time_to_go.toSeconds(), -60);
     ASSERT_EQ(feedback.alarm_condition_active, "OFF");
     ASSERT_EQ(feedback.relay_state, "OFF");
@@ -176,7 +176,7 @@ TEST_F(DriverTest, rejects_a_partial_packet_and_accepts_following_full_one)
     ASSERT_EQ(feedback.current, 0);
     ASSERT_NEAR(feedback.instantaneous_power, 0, 1e-3);
     ASSERT_EQ(feedback.consumed_charge, 0);
-    ASSERT_NEAR(feedback.state_of_charge, 1000, 1e-3);
+    ASSERT_NEAR(feedback.state_of_charge, 100, 1e-3);
     ASSERT_EQ(feedback.time_to_go.toSeconds(), -60);
     ASSERT_EQ(feedback.alarm_condition_active, "OFF");
     ASSERT_EQ(feedback.relay_state, "OFF");

--- a/test/test_Driver.cpp
+++ b/test/test_Driver.cpp
@@ -53,7 +53,7 @@ TEST_F(DriverTest, it_accepts_a_full_packet)
                       "\x33\x30\x37\x0d\x0a\x43\x68\x65\x63\x6b\x73\x75\x6d\x09"
                       "\xd8";
     pushDataToDriver(msg);
-    auto feedback = driver.processOne();
+    auto feedback = driver.processOne(2);
     ASSERT_EQ(feedback.product_id, "0x203");
     ASSERT_NEAR(feedback.voltage, 26.201, 1e-3);
     ASSERT_EQ(feedback.current, 0);
@@ -81,7 +81,7 @@ TEST_F(DriverTest, it_rejects_a_packet_because_the_checksum_is_wrong)
                       "\x33\x30\x37\x0d\x0a\x43\x68\x65\x63\x6b\x73\x75\x6d\x09"
                       "\xd7";
     pushDataToDriver(msg);
-    ASSERT_THROW_MESSAGE(driver.processOne(),
+    ASSERT_THROW_MESSAGE(driver.processOne(2),
         std::runtime_error,
         "readPacket(): no data to read while a packet_timeout of 0 was given");
 }
@@ -98,12 +98,12 @@ TEST_F(DriverTest, the_packet_arrives_little_by_little)
                       "\x6c\x61\x79\x09\x4f\x46\x46\x0d\x0a\x41\x52\x09\x30\x0d"
                       "\x0a\x42\x4d\x56\x09\x37\x30\x30\x0d\x0a\x46\x57\x09\x30";
     pushDataToDriver(msg);
-    ASSERT_THROW_MESSAGE(driver.processOne(),
+    ASSERT_THROW_MESSAGE(driver.processOne(2),
         std::runtime_error,
         "readPacket(): no data to read while a packet_timeout of 0 was given");
     msg = "\x33\x30\x37\x0d\x0a\x43\x68\x65\x63\x6b\x73\x75\x6d\x09\xd8";
     pushDataToDriver(msg);
-    auto feedback = driver.processOne();
+    auto feedback = driver.processOne(2);
     ASSERT_EQ(feedback.product_id, "0x203");
     ASSERT_NEAR(feedback.voltage, 26.201, 1e-3);
     ASSERT_EQ(feedback.current, 0);
@@ -132,7 +132,7 @@ TEST_F(DriverTest, it_accepts_a_packet_with_garbage_at_the_beginning)
         "\x0a\x42\x4d\x56\x09\x37\x30\x30\x0d\x0a\x46\x57\x09\x30\x33\x30\x37\x0d\x0a\x43"
         "\x68\x65\x63\x6b\x73\x75\x6d\x09\xd8";
     pushDataToDriver(msg);
-    auto feedback = driver.processOne();
+    auto feedback = driver.processOne(2);
     ASSERT_EQ(feedback.product_id, "0x203");
     ASSERT_NEAR(feedback.voltage, 26.201, 1e-3);
     ASSERT_EQ(feedback.current, 0);
@@ -156,7 +156,7 @@ TEST_F(DriverTest, rejects_a_partial_packet_and_accepts_following_full_one)
                       "\x33\x30\x37\x0d\x0a\x43\x68\x65\x63\x6b\x73\x75\x6d\x09"
                       "\xd8";
     pushDataToDriver(msg);
-    ASSERT_THROW_MESSAGE(driver.processOne(),
+    ASSERT_THROW_MESSAGE(driver.processOne(2),
         std::runtime_error,
         "readPacket(): no data to read while a packet_timeout of 0 was given");
     // Full packet
@@ -170,7 +170,7 @@ TEST_F(DriverTest, rejects_a_partial_packet_and_accepts_following_full_one)
           "\x33\x30\x37\x0d\x0a\x43\x68\x65\x63\x6b\x73\x75\x6d\x09"
           "\xd8";
     pushDataToDriver(msg);
-    auto feedback = driver.processOne();
+    auto feedback = driver.processOne(2);
     ASSERT_EQ(feedback.product_id, "0x203");
     ASSERT_NEAR(feedback.voltage, 26.201, 1e-3);
     ASSERT_EQ(feedback.current, 0);
@@ -191,7 +191,7 @@ TEST_F(DriverTest, it_correctly_parses_the_MON_0_field)
     // Partial packet
     auto buffer = readTextFile(TEST_PATH "mon_0.dat");
     pushDataToDriver(buffer);
-    auto result = driver.processOne();
+    auto result = driver.processOne(2);
     ASSERT_EQ(0, result.dc_monitor_mode);
 }
 
@@ -203,12 +203,12 @@ TEST_F(DriverTest, it_updates_the_processed_packet_counter)
     auto buffer = readTextFile(TEST_PATH "mon_0.dat");
     pushDataToDriver(buffer);
     ASSERT_EQ(0, driver.packetsCounter());
-    auto result = driver.processOne();
+    auto result = driver.processOne(2);
     ASSERT_EQ(1, driver.packetsCounter());
     pushDataToDriver(buffer);
-    result = driver.processOne();
+    result = driver.processOne(2);
     ASSERT_EQ(2, driver.packetsCounter());
     pushDataToDriver(buffer);
-    result = driver.processOne();
+    result = driver.processOne(2);
     ASSERT_EQ(1, driver.packetsCounter());
 }

--- a/test/test_Driver.cpp
+++ b/test/test_Driver.cpp
@@ -194,3 +194,21 @@ TEST_F(DriverTest, it_correctly_parses_the_MON_0_field)
     auto result = driver.processOne();
     ASSERT_EQ(0, result.dc_monitor_mode);
 }
+
+TEST_F(DriverTest, it_updates_the_processed_packet_counter)
+{
+    openDriver();
+    IODRIVERS_BASE_MOCK();
+    // Partial packet
+    auto buffer = readTextFile(TEST_PATH "mon_0.dat");
+    pushDataToDriver(buffer);
+    ASSERT_EQ(0, driver.packetsCounter());
+    auto result = driver.processOne();
+    ASSERT_EQ(1, driver.packetsCounter());
+    pushDataToDriver(buffer);
+    result = driver.processOne();
+    ASSERT_EQ(2, driver.packetsCounter());
+    pushDataToDriver(buffer);
+    result = driver.processOne();
+    ASSERT_EQ(1, driver.packetsCounter());
+}

--- a/test/test_Protocol.cpp
+++ b/test/test_Protocol.cpp
@@ -37,7 +37,8 @@ TEST_F(ProtocolTest, it_accepts_a_packet_and_correctly_parse_it)
     std::vector<uint8_t> checksum_field =
         {0x0d, 0x0a, 0x43, 0x68, 0x65, 0x63, 0x6b, 0x73, 0x75, 0x6d, 0x09, 0xbe};
     buffer.insert(buffer.end(), checksum_field.begin(), checksum_field.end());
-    auto feedback = parseSmartShuntFeedback(&buffer[0], 631);
+    SmartShuntFeedback feedback;
+    parseSmartShuntFeedback(&buffer[0], 631, feedback);
     ASSERT_EQ(619, extractPacket(&buffer[0], 631));
     ASSERT_NEAR(feedback.voltage, 32.456, 1e-3);
     ASSERT_NEAR(feedback.auxiliary_starter_voltage, 14.45, 1e-3);

--- a/test/test_Protocol.cpp
+++ b/test/test_Protocol.cpp
@@ -48,7 +48,7 @@ TEST_F(ProtocolTest, it_accepts_a_packet_and_correctly_parse_it)
     ASSERT_NEAR(feedback.temperature.getCelsius(), 27, 1e-3);
     ASSERT_NEAR(feedback.instantaneous_power, 600, 1e-3);
     ASSERT_NEAR(feedback.consumed_charge, 54720, 1e-3);
-    ASSERT_NEAR(feedback.state_of_charge, 85, 1e-3);
+    ASSERT_NEAR(feedback.state_of_charge, 8.5, 1e-3);
     ASSERT_EQ(feedback.time_to_go.toSeconds(), 120 * 60);
     ASSERT_EQ(feedback.alarm_condition_active, "ON");
     ASSERT_EQ(feedback.relay_state, "ON");


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/tidewise/drivers-orogen-bms_victron_smart_shunt/pull/3

# What is this PR for
merge packets to compose feedback struct
the device sends the data divided into two packets, so it's necessary to merge the data to compose the feedback struct
![image](https://github.com/user-attachments/assets/f686976b-becd-4d9b-bdca-3b3789a25c83)
![image](https://github.com/user-attachments/assets/db46c2b2-c29b-425e-b844-6e50400a8444)

# Checklist
- [x] Assign yourself  in the PR
- [ ] Write unit tests (when relevant)
- [ ] Run rubocop and rake tests locally
- [ ] If this PR initialize a CMAKE package please [enable styling and linting](https://github.com/tidewise/wetpaint-buildconf/blob/master/README.md#enabling-styling-and-linting-checks-for-a-cmake-package)
- [ ] Analyse if this PR modifies the UI, if so:
    - [ ] Tested Tupan's simulation (Charts) :world_map:
    - [ ] Tested Tupan's simulation (Hud) :joystick:
    - [ ] Tested ROV's simulation :joystick:
