### PR TITLE
feat: update feedback structure upon every packet arrival

### DIFF
--- a/src/Driver.cpp
+++ b/src/Driver.cpp
@@ -6,7 +6,6 @@ using namespace bms_victron_smart_shunt;
 Driver::Driver()
     : iodrivers_base::Driver::Driver(INTERNAL_BUFFER_SIZE)
 {
-    m_processed_packets_counter = 0;
 }
 
 int Driver::extractPacket(uint8_t const* buffer, size_t buffer_size) const
@@ -14,20 +13,9 @@ int Driver::extractPacket(uint8_t const* buffer, size_t buffer_size) const
     return protocol::extractPacket(buffer, buffer_size);
 }
 
-SmartShuntFeedback Driver::processOne(int needed_packets)
+SmartShuntFeedback Driver::processOne()
 {
-    if (m_processed_packets_counter >= needed_packets) {
-        // Reset feedback
-        m_feedback = SmartShuntFeedback();
-        m_processed_packets_counter = 0;
-    }
     int packet_size = readPacket(m_read_buffer, INTERNAL_BUFFER_SIZE);
     protocol::parseSmartShuntFeedback(m_read_buffer, packet_size, m_feedback);
-    m_processed_packets_counter += 1;
     return m_feedback;
-}
-
-int Driver::packetsCounter()
-{
-    return m_processed_packets_counter;
 }

--- a/src/Driver.hpp
+++ b/src/Driver.hpp
@@ -20,18 +20,9 @@ namespace bms_victron_smart_shunt {
         /**
          * @brief Process the internal buffer and parses the a found packet
          *
-         * @param needed_packets The number of needed packets to compose a full feedback
-         * update
          * @return SmartShuntFeedback
          */
-        SmartShuntFeedback processOne(int needed_packets);
-        /**
-         * @brief Returns the number of packets processed to compose the current feedback
-         * struct
-         *
-         * @return int
-         */
-        int packetsCounter();
+        SmartShuntFeedback processOne();
 
     private:
         /**
@@ -52,12 +43,6 @@ namespace bms_victron_smart_shunt {
          *
          */
         SmartShuntFeedback m_feedback;
-        /**
-         * @brief The number of processed packets used to compose the current feedback
-         * struct
-         *
-         */
-        int m_processed_packets_counter = 0;
     };
 }
 

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -9,12 +9,10 @@ using namespace bms_victron_smart_shunt;
 int usage()
 {
     cerr << "Usage: "
-         << "bms_victron_smart_shunt_ctl URI PERIOD NEEDED_PACKETS \n"
+         << "bms_victron_smart_shunt_ctl URI PERIOD \n"
          << "URI is a valid iodrivers_base URI, e.g. serial:///dev/ttyUSB0:19200\n"
          << "PERIOD is time interval in seconds between two outputs, the default value "
             "is 0.1 seconds\n"
-         << "NEEDED_PACKETS The number of packets needed to have a full feedback update\n"
-
          << flush;
     return 0;
 }
@@ -33,67 +31,58 @@ int main(int argc, char const* argv[])
     if (argc >= 3) {
         poll_period_usec = atof(argv[2]) * 1000000;
     }
-    int needed_packets = 2;
-    if (argc >= 4) {
-        needed_packets = atof(argv[3]);
-    }
-
     while (true) {
-        auto feedback = driver.processOne(needed_packets);
-        if (driver.packetsCounter() >= 2) {
-            cout << fixed << std::left << std::setw(42)
-                 << "\nTimestamp: " << feedback.timestamp << std::left << std::setw(42)
-                 << "\nProduct ID: " << feedback.product_id << std::left << std::setw(42)
-                 << "\nVoltage: " << setprecision(3) << feedback.voltage << std::left
-                 << std::setw(42) << "\nCurrent: " << feedback.current << std::left
-                 << std::setw(42) << "\nInstantaneous power: " << setprecision(0)
-                 << feedback.instantaneous_power << std::left << std::setw(42)
-                 << "\nConsumed charge: " << setprecision(3) << feedback.consumed_charge
-                 << std::left << std::setw(42) << "\nState of charge: " << setprecision(0)
-                 << feedback.state_of_charge << std::left << std::setw(42)
-                 << "\nTime to go (s): " << feedback.time_to_go.toSeconds() << std::left
-                 << std::setw(42)
-                 << "\nAlarm condition active: " << feedback.alarm_condition_active
-                 << std::left << std::setw(42)
-                 << "\nAlarm reason: " << feedback.alarm_reason << std::left
-                 << std::setw(42) << "\nModel description: " << feedback.model_description
-                 << std::left << std::setw(42)
-                 << "\nFirmware version: " << feedback.firmware_version << std::left
-                 << std::setw(42) << "\nDC monitor mode: " << feedback.dc_monitor_mode
-                 << std::left << std::setw(42)
-                 << "\nCharged energy: " << feedback.charged_energy << std::left
-                 << std::setw(42)
-                 << "\nDeepest discharge depth: " << feedback.deepest_discharge_depth
-                 << std::left << std::setw(42)
-                 << "\nLast discharge depth: " << feedback.last_discharge_depth
-                 << std::left << std::setw(42)
-                 << "\nAverage discharge depth: " << feedback.average_discharge_depth
-                 << std::left << std::setw(42)
-                 << "\nCharge cycles number: " << feedback.charge_cycles_number
-                 << std::left << std::setw(42)
-                 << "\nFull discharges number: " << feedback.full_discharges_number
-                 << std::left << std::setw(42)
-                 << "\nCumulative charge drawn: " << feedback.cumulative_charge_drawn
-                 << std::left << std::setw(42) << "\nMinimum voltage: " << setprecision(3)
-                 << feedback.minimum_voltage << std::left << std::setw(42)
-                 << "\nMaximum voltage: " << feedback.maximum_voltage << std::left
-                 << std::setw(42)
-                 << "\nSeconds since last full charge: " << setprecision(0)
-                 << feedback.seconds_since_last_full_charge.toSeconds() << std::left
-                 << std::setw(42) << "\nNumber of automatic synchronizations: "
-                 << feedback.automatic_synchronizations_number << std::left
-                 << std::setw(42) << "\nNumber of low voltage alarms: "
-                 << feedback.low_voltage_alarms_number << std::left << std::setw(42)
-                 << "\nNumber of high voltage alarms: "
-                 << feedback.high_voltage_alarms_number << std::left << std::setw(42)
-                 << "\nMinimum auxiliary battery voltage: " << setprecision(3)
-                 << feedback.minimum_auxiliary_battery_voltage << std::left
-                 << std::setw(42) << "\nMaximum auxiliary battery voltage: "
-                 << feedback.maximum_auxiliary_battery_voltage << std::left
-                 << std::setw(42) << "\nDischarged energy: " << setprecision(0)
-                 << feedback.discharged_energy << std::left << std::setw(42)
-                 << "\nCharged energy: " << feedback.charged_energy << endl;
-        }
+        auto feedback = driver.processOne();
+        cout << fixed << std::left << std::setw(42)
+             << "\nTimestamp: " << feedback.timestamp << std::left << std::setw(42)
+             << "\nProduct ID: " << feedback.product_id << std::left << std::setw(42)
+             << "\nVoltage: " << setprecision(3) << feedback.voltage << std::left
+             << std::setw(42) << "\nCurrent: " << feedback.current << std::left
+             << std::setw(42) << "\nInstantaneous power: " << setprecision(0)
+             << feedback.instantaneous_power << std::left << std::setw(42)
+             << "\nConsumed charge: " << setprecision(3) << feedback.consumed_charge
+             << std::left << std::setw(42) << "\nState of charge: " << setprecision(0)
+             << feedback.state_of_charge << std::left << std::setw(42)
+             << "\nTime to go (s): " << feedback.time_to_go.toSeconds() << std::left
+             << std::setw(42)
+             << "\nAlarm condition active: " << feedback.alarm_condition_active
+             << std::left << std::setw(42) << "\nAlarm reason: " << feedback.alarm_reason
+             << std::left << std::setw(42)
+             << "\nModel description: " << feedback.model_description << std::left
+             << std::setw(42) << "\nFirmware version: " << feedback.firmware_version
+             << std::left << std::setw(42)
+             << "\nDC monitor mode: " << feedback.dc_monitor_mode << std::left
+             << std::setw(42) << "\nCharged energy: " << feedback.charged_energy
+             << std::left << std::setw(42)
+             << "\nDeepest discharge depth: " << feedback.deepest_discharge_depth
+             << std::left << std::setw(42)
+             << "\nLast discharge depth: " << feedback.last_discharge_depth << std::left
+             << std::setw(42)
+             << "\nAverage discharge depth: " << feedback.average_discharge_depth
+             << std::left << std::setw(42)
+             << "\nCharge cycles number: " << feedback.charge_cycles_number << std::left
+             << std::setw(42)
+             << "\nFull discharges number: " << feedback.full_discharges_number
+             << std::left << std::setw(42)
+             << "\nCumulative charge drawn: " << feedback.cumulative_charge_drawn
+             << std::left << std::setw(42) << "\nMinimum voltage: " << setprecision(3)
+             << feedback.minimum_voltage << std::left << std::setw(42)
+             << "\nMaximum voltage: " << feedback.maximum_voltage << std::left
+             << std::setw(42) << "\nSeconds since last full charge: " << setprecision(0)
+             << feedback.seconds_since_last_full_charge.toSeconds() << std::left
+             << std::setw(42) << "\nNumber of automatic synchronizations: "
+             << feedback.automatic_synchronizations_number << std::left << std::setw(42)
+             << "\nNumber of low voltage alarms: " << feedback.low_voltage_alarms_number
+             << std::left << std::setw(42)
+             << "\nNumber of high voltage alarms: " << feedback.high_voltage_alarms_number
+             << std::left << std::setw(42)
+             << "\nMinimum auxiliary battery voltage: " << setprecision(3)
+             << feedback.minimum_auxiliary_battery_voltage << std::left << std::setw(42)
+             << "\nMaximum auxiliary battery voltage: "
+             << feedback.maximum_auxiliary_battery_voltage << std::left << std::setw(42)
+             << "\nDischarged energy: " << setprecision(0) << feedback.discharged_energy
+             << std::left << std::setw(42)
+             << "\nCharged energy: " << feedback.charged_energy << endl;
         usleep(poll_period_usec);
     }
 }

--- a/test/test_Driver.cpp
+++ b/test/test_Driver.cpp
@@ -53,7 +53,7 @@ TEST_F(DriverTest, it_accepts_a_full_packet)
                       "\x33\x30\x37\x0d\x0a\x43\x68\x65\x63\x6b\x73\x75\x6d\x09"
                       "\xd8";
     pushDataToDriver(msg);
-    auto feedback = driver.processOne(2);
+    auto feedback = driver.processOne();
     ASSERT_EQ(feedback.product_id, "0x203");
     ASSERT_NEAR(feedback.voltage, 26.201, 1e-3);
     ASSERT_EQ(feedback.current, 0);
@@ -81,7 +81,7 @@ TEST_F(DriverTest, it_rejects_a_packet_because_the_checksum_is_wrong)
                       "\x33\x30\x37\x0d\x0a\x43\x68\x65\x63\x6b\x73\x75\x6d\x09"
                       "\xd7";
     pushDataToDriver(msg);
-    ASSERT_THROW_MESSAGE(driver.processOne(2),
+    ASSERT_THROW_MESSAGE(driver.processOne(),
         std::runtime_error,
         "readPacket(): no data to read while a packet_timeout of 0 was given");
 }
@@ -98,12 +98,12 @@ TEST_F(DriverTest, the_packet_arrives_little_by_little)
                       "\x6c\x61\x79\x09\x4f\x46\x46\x0d\x0a\x41\x52\x09\x30\x0d"
                       "\x0a\x42\x4d\x56\x09\x37\x30\x30\x0d\x0a\x46\x57\x09\x30";
     pushDataToDriver(msg);
-    ASSERT_THROW_MESSAGE(driver.processOne(2),
+    ASSERT_THROW_MESSAGE(driver.processOne(),
         std::runtime_error,
         "readPacket(): no data to read while a packet_timeout of 0 was given");
     msg = "\x33\x30\x37\x0d\x0a\x43\x68\x65\x63\x6b\x73\x75\x6d\x09\xd8";
     pushDataToDriver(msg);
-    auto feedback = driver.processOne(2);
+    auto feedback = driver.processOne();
     ASSERT_EQ(feedback.product_id, "0x203");
     ASSERT_NEAR(feedback.voltage, 26.201, 1e-3);
     ASSERT_EQ(feedback.current, 0);
@@ -132,7 +132,7 @@ TEST_F(DriverTest, it_accepts_a_packet_with_garbage_at_the_beginning)
         "\x0a\x42\x4d\x56\x09\x37\x30\x30\x0d\x0a\x46\x57\x09\x30\x33\x30\x37\x0d\x0a\x43"
         "\x68\x65\x63\x6b\x73\x75\x6d\x09\xd8";
     pushDataToDriver(msg);
-    auto feedback = driver.processOne(2);
+    auto feedback = driver.processOne();
     ASSERT_EQ(feedback.product_id, "0x203");
     ASSERT_NEAR(feedback.voltage, 26.201, 1e-3);
     ASSERT_EQ(feedback.current, 0);
@@ -156,7 +156,7 @@ TEST_F(DriverTest, rejects_a_partial_packet_and_accepts_following_full_one)
                       "\x33\x30\x37\x0d\x0a\x43\x68\x65\x63\x6b\x73\x75\x6d\x09"
                       "\xd8";
     pushDataToDriver(msg);
-    ASSERT_THROW_MESSAGE(driver.processOne(2),
+    ASSERT_THROW_MESSAGE(driver.processOne(),
         std::runtime_error,
         "readPacket(): no data to read while a packet_timeout of 0 was given");
     // Full packet
@@ -170,7 +170,7 @@ TEST_F(DriverTest, rejects_a_partial_packet_and_accepts_following_full_one)
           "\x33\x30\x37\x0d\x0a\x43\x68\x65\x63\x6b\x73\x75\x6d\x09"
           "\xd8";
     pushDataToDriver(msg);
-    auto feedback = driver.processOne(2);
+    auto feedback = driver.processOne();
     ASSERT_EQ(feedback.product_id, "0x203");
     ASSERT_NEAR(feedback.voltage, 26.201, 1e-3);
     ASSERT_EQ(feedback.current, 0);
@@ -191,24 +191,6 @@ TEST_F(DriverTest, it_correctly_parses_the_MON_0_field)
     // Partial packet
     auto buffer = readTextFile(TEST_PATH "mon_0.dat");
     pushDataToDriver(buffer);
-    auto result = driver.processOne(2);
+    auto result = driver.processOne();
     ASSERT_EQ(0, result.dc_monitor_mode);
-}
-
-TEST_F(DriverTest, it_updates_the_processed_packet_counter)
-{
-    openDriver();
-    IODRIVERS_BASE_MOCK();
-    // Partial packet
-    auto buffer = readTextFile(TEST_PATH "mon_0.dat");
-    pushDataToDriver(buffer);
-    ASSERT_EQ(0, driver.packetsCounter());
-    auto result = driver.processOne(2);
-    ASSERT_EQ(1, driver.packetsCounter());
-    pushDataToDriver(buffer);
-    result = driver.processOne(2);
-    ASSERT_EQ(2, driver.packetsCounter());
-    pushDataToDriver(buffer);
-    result = driver.processOne(2);
-    ASSERT_EQ(1, driver.packetsCounter());
 }


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/tidewise/drivers-orogen-bms_victron_smart_shunt/pull/6
- [ ] https://github.com/tidewise/bundles-lars/pull/154

# What is this PR for
feat: update feedback structure upon every packet arrival

The number of necessary packet to compose a full feedback is unknown.
There is no information in the user manual and looks like the way that the device sends the info at the packets is not consistent.
So we decided to update the feedback upon every packet arrival.

https://github.com/user-attachments/assets/a8827697-9c66-4d05-b60c-180f48b4eca2


# Checklist
- [x] Assign yourself  in the PR
