### PR TITLE
fix: return the packet size for valid packets

### DIFF
--- a/src/Protocol.cpp
+++ b/src/Protocol.cpp
@@ -34,8 +34,7 @@ int protocol::extractPacket(const uint8_t* buffer, int buffer_size)
         checksum = (checksum + buffer[i]) & 255;
     }
     if (checksum == 0) {
-        // Returns the packet size without the checksum field
-        return checksum_begin_it - buffer - 2;
+        return packet_size;
     }
     else {
         return -1;

--- a/test/test_Driver.cpp
+++ b/test/test_Driver.cpp
@@ -194,3 +194,18 @@ TEST_F(DriverTest, it_correctly_parses_the_MON_0_field)
     auto result = driver.processOne();
     ASSERT_EQ(0, result.dc_monitor_mode);
 }
+
+TEST_F(DriverTest, it_does_not_increase_bad_rx_number_for_valid_packets_processing)
+{
+    openDriver();
+    IODRIVERS_BASE_MOCK();
+    auto buffer = readTextFile(TEST_PATH "mon_0.dat");
+    pushDataToDriver(buffer);
+    auto result = driver.processOne();
+    auto stats = driver.getStats();
+    ASSERT_EQ(0, result.dc_monitor_mode);
+    pushDataToDriver(buffer);
+    result = driver.processOne();
+    stats = driver.getStats();
+    ASSERT_EQ(0, stats.bad_rx);
+}

--- a/test/test_Protocol.cpp
+++ b/test/test_Protocol.cpp
@@ -39,7 +39,7 @@ TEST_F(ProtocolTest, it_accepts_a_packet_and_correctly_parse_it)
     buffer.insert(buffer.end(), checksum_field.begin(), checksum_field.end());
     SmartShuntFeedback feedback;
     parseSmartShuntFeedback(&buffer[0], 631, feedback);
-    ASSERT_EQ(619, extractPacket(&buffer[0], 631));
+    ASSERT_EQ(631, extractPacket(&buffer[0], 631));
     ASSERT_NEAR(feedback.voltage, 32.456, 1e-3);
     ASSERT_NEAR(feedback.auxiliary_starter_voltage, 14.45, 1e-3);
     ASSERT_NEAR(feedback.mid_point_voltage, 15.5, 1e-3);


### PR DESCRIPTION
# What is this PR for
fix: return the packet size for valid packets instead of return the packet size without the checksum field

The old implementation used to make the bad rx value of the status port to increase, indicating wrongly a packet loss.

# Results, How I tested
Analyzing the bad_rx value from a log of 30 seconds

## Old implantation
![image](https://github.com/user-attachments/assets/360f52e6-b7f0-4eff-87d6-0145c12ed0ab)

## New implementation
![image](https://github.com/user-attachments/assets/efc297c8-cc40-4db5-b7ca-3dcfba625750)

# Checklist
- [x] Assign yourself  in the PR