### PR TITLE
fix: fix the wait for the checksum value

### DIFF
--- a/src/Protocol.cpp
+++ b/src/Protocol.cpp
@@ -28,6 +28,10 @@ int protocol::extractPacket(const uint8_t* buffer, int buffer_size)
         return 0;
     }
     int packet_size = checksum_begin_it - buffer + CHECKSUM_STR_LEN + 2;
+    if (buffer_size < packet_size) {
+        // There is checksum, but not its value yet, wait for more bytes
+        return 0;
+    }
     int checksum = 0;
     for (int i = 0; i < packet_size; i++) {
         // Take modulo 256 in account


### PR DESCRIPTION
# What is this PR for
Wait for more bytes if the checksum value is not present in the packet yet

The device could send a message with the checksum present, but with its value not present. In this case the driver should wait for more bytes.

# Results, How I tested
Add a test that mocks the device sending the message byte by byte

# Checklist
- [x] Assign yourself  in the PR
- [x] Write unit tests (when relevant)
